### PR TITLE
Load instagram data from the "self" user

### DIFF
--- a/src/pages/career/backend-developer/index.hbs
+++ b/src/pages/career/backend-developer/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/frontend-developer/index.hbs
+++ b/src/pages/career/frontend-developer/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/gbg-developer/index.hbs
+++ b/src/pages/career/gbg-developer/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/gbg-front-end-dev/index.hbs
+++ b/src/pages/career/gbg-front-end-dev/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/index.hbs
+++ b/src/pages/career/index.hbs
@@ -25,7 +25,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/senior-developer/index.hbs
+++ b/src/pages/career/senior-developer/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/career/system-developer/index.hbs
+++ b/src/pages/career/system-developer/index.hbs
@@ -24,7 +24,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -62,7 +62,7 @@ partials:
     type: instagram
     background-color: black
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
   -

--- a/src/pages/news/competency/index.hbs
+++ b/src/pages/news/competency/index.hbs
@@ -21,7 +21,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---

--- a/src/pages/news/newoffice/index.hbs
+++ b/src/pages/news/newoffice/index.hbs
@@ -21,7 +21,7 @@ partials:
   -
     type: instagram
     social-media:
-      instagram: iteam1337
+      instagram: self
     instagram-count: 4
     instagram-resolution: normal
 ---


### PR DESCRIPTION
Since Instagram now requires API requests to be authenticated, we can only get data from our own account (aliased "self" in their API). This PR changes all requests to now be `https://insta-team.iteamdev.se/user/self` so this is fulfilled.

